### PR TITLE
Fixing #2 and wrong paths on xubuntu.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,6 @@ target_link_libraries(thunar-dropbox ${GIO_LIBRARIES})
 
 # Installation
 install(TARGETS thunar-dropbox
-        DESTINATION "lib/thunarx-3")
+        DESTINATION "thunarx-3")
 install(FILES "data/icons/hicolor/16x16/apps/thunar-dropbox.png"
         DESTINATION "share/icons/hicolor/16x16/apps")

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plugin is available in the repositories of most distributions, check it out 
 </a>
 
 ### From source
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr .
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr/lib .
     cmake --build build
 
 The first call to cmake configures the build system. The -B flag specifies the output directory, here _build_. The dot at the end is the path to the directory containing _CMakeLists.txt_.  

--- a/src/tdp-provider.c
+++ b/src/tdp-provider.c
@@ -258,7 +258,7 @@ static GList * tdp_provider_get_file_actions(
             g_free(line);
         }
         else if (status == G_IO_STATUS_AGAIN) {
-            break;
+            continue;
         }
         else if (status == G_IO_STATUS_ERROR) {
             break;


### PR DESCRIPTION
I experienced #2 (like, without any exceptions, but admittedly on a quite slow machine, i5-2410M), and the fix proposed there seems to do the trick. Instead of removing the lines, I made the `continue` more explicit.

When trying to install the version from this repository, the paths were slightly wrong. The shared library got installed here:

> `/usr/lib/x86_64-linux-gnu/lib/thunarx-3/thunar-dropbox.so`,

whereas it should have been installed here:

> `/usr/lib/x86_64-linux-gnu/thunarx-3/thunar-dropbox.so`

So I did an attempt to fix that, but since I am not familiar with CMAKE, this might mess up things for other platforms than Xubuntu 20.04.